### PR TITLE
Remove assign user button from the user-selector

### DIFF
--- a/app/components/user-selector.hbs
+++ b/app/components/user-selector.hbs
@@ -1,6 +1,6 @@
 {{!-- app/components/user-selector.hbs --}}
 <div class="user-selector">
-  <form {{on "submit" this.handleSubmit}}>
+  <form>
     <label for="assign-user">Select a user:</label>
     <select id="assign-user" name="assign-user" value={{this.selectedUserId}} {{on "change" this.handleChange}} data-test-selector="selector">
       {{#each this.userOptions as |user|}}
@@ -10,6 +10,5 @@
       </option>
       {{/each}}
     </select>
-    <button data-test-us-button="has assign user text" type="submit">Assign user</button>
   </form>
 </div>

--- a/app/components/user-selector.js
+++ b/app/components/user-selector.js
@@ -19,16 +19,9 @@ export default class UserSelectorComponent extends Component {
 
   @action
   handleChange(event) {
-    // Update the selected user ID when the selection changes
+    // Update the selected user ID when the selection changes - store it locally until we grab it in edit-task controller
     this.selectedUserId = event.target.value;
-  }
 
-  @action
-  handleSubmit(event) {
-    // Prevent the default form submission behavior
-    event.preventDefault();
-    // Call the onUserAssign function which is up in the route tasks controller with the task ID and selected user ID
-    this.args.onUserAssign(this.args.task.id, this.selectedUserId);
   }
 
   get userOptions() {

--- a/app/controllers/tasks/edit-task.js
+++ b/app/controllers/tasks/edit-task.js
@@ -36,23 +36,15 @@ export default class TasksEditTaskController extends Controller {
     let taskName = event.target.taskName.value;
     let taskDescription = event.target.taskDescription.value;
 
-    // Update the model with new values
+    // Update the task with new values
     this.model.title = taskName;
     this.model.description = taskDescription;
 
+    // update the user with the task from the option list component selector
+    let selectedUserId = event.target.querySelector('#assign-user').value;
+    let assignedUser = this.users.find((user) => user.id === selectedUserId);
+    this.model.set('user', assignedUser);
+    console.log(selectedUserId, assignedUser);
     this.closeModal();
-  }
-
-  @action
-  // take the taskId, userId and find the correct task and user. 
-  // Then tell Ember Data that the task now belongs to the selected user.
-  // Ember Data automatically updates the user's tasks relationship to 
-  // include the task because of the inverse relationship defined in the model.
-  assignUser(taskId, userId) {
-    let task = this.tasks.find((task) => task.id === taskId);
-    let user = this.users.find((user) => user.id === userId);
-
-    // no checks needed here for null values as a task not linked wont have a user_id - this will be a valid case so we just set
-    task.set('user', user);
   }
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -392,7 +392,7 @@ nav a:hover {
 /* Push the Save button to the right of its container */
 .form-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   margin-bottom: 20px;
 }
 

--- a/app/templates/tasks/edit-task.hbs
+++ b/app/templates/tasks/edit-task.hbs
@@ -28,6 +28,7 @@
             </div>
 
             <div class="form-actions">
+                <button type="button" class="default-button red-button" {{on "click" this.closeModal}}>Cancel</button>
                 <button type="submit" class="default-button green-button">Save</button>
             </div>
         </div>


### PR DESCRIPTION
I wanted to remove the assign user button from the user selector.
It feels better to have the edit-task save button save all changes made to a task instead.

- Removed the form submit action and button from the user-selector component
- Removed the handleSubmit action from the component class
- Removed assignUser from the edit-task controller
- Updated the editTask action to save the change in user
- Added a cancel button to the edit-task form